### PR TITLE
nro fix for spider and new issue/pr templates

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,3 @@
+# Title
+
+One to two sentence description. Add current and expected behavior if the issue is a bug.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+# Title
+
+## Motivation
+
+Why was this made?
+
+## Implementation
+
+How was this acomplished?
+
+### Usage
+
+How can we test out this feature?
+
+## Demo (screenshots, animations)
+
+Please attach screenshots or screen recordings if you made a UI change.
+
+## Referenced Issue(s)
+
+- [Issue Number](Link)

--- a/apps/spider/crawlers/timetable.py
+++ b/apps/spider/crawlers/timetable.py
@@ -51,7 +51,7 @@ def crawl_timetable(term):
         preprocess=lambda x: re.sub("</tr>", "", x),
     )
     num_columns = len(soup.find(class_="data-table").find_all("th"))
-    assert num_columns == 18
+    assert num_columns == 19
 
     tds = soup.find(class_="data-table").find_all("td")
     assert len(tds) % num_columns == 0

--- a/apps/spider/crawlers/timetable.py
+++ b/apps/spider/crawlers/timetable.py
@@ -51,7 +51,7 @@ def crawl_timetable(term):
         preprocess=lambda x: re.sub("</tr>", "", x),
     )
     num_columns = len(soup.find(class_="data-table").find_all("th"))
-    assert num_columns == 19
+    assert (num_columns == 18 or num_columns == 19)
 
     tds = soup.find(class_="data-table").find_all("td")
     assert len(tds) % num_columns == 0

--- a/apps/spider/crawlers/timetable.py
+++ b/apps/spider/crawlers/timetable.py
@@ -51,7 +51,7 @@ def crawl_timetable(term):
         preprocess=lambda x: re.sub("</tr>", "", x),
     )
     num_columns = len(soup.find(class_="data-table").find_all("th"))
-    assert (num_columns == 18 or num_columns == 19)
+    assert num_columns == 19
 
     tds = soup.find(class_="data-table").find_all("td")
     assert len(tds) % num_columns == 0


### PR DESCRIPTION
# nro fix for spider and new issue/pr templates

## Motivation

Dartmouth added an NRO/CT field to the timetable, which breaks the current timetable scraper.

## Implementation

This PR switches the timetable column assertion to 19 columns and ignores the NR field (no way to display that in the frontend as of now, so no point to adding it in!). 

### Usage

apps/spider will automatically run, should succeed now!
