### PR TITLE
bumping psycopg2 version to 2.8.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ pathlib2==2.1.0
 pexpect==4.2.1
 pickleshare==0.7.4
 prompt-toolkit==1.0.9
-psycopg2==2.6.2
+psycopg2==2.8.5
 ptyprocess==0.5.1
 PyExecJS==1.4.0
 Pygments==2.1.3


### PR DESCRIPTION
# bumping psycopg2 version to 2.8.5

version update, old one no longer compiles.