### PR TITLE
added support for .mt email extension

### DIFF
--- a/apps/web/models/student.py
+++ b/apps/web/models/student.py
@@ -20,7 +20,8 @@ class StudentManager(models.Manager):
         return (
             domain == "dartmouth.edu" and
             len(year) == 2 and
-            (year.isdigit() or year.lower() == "ug" or year.lower() == "gr")
+            (year.isdigit() or year.lower() == "ug" or year.lower() == "gr"
+                or year.lower() == "mt")
         )
 
 


### PR DESCRIPTION
# added support for .mt email extension

## Motivation

Starting (it appears) with the class of '24, transfer students may be assigned `.mt` email addresses. This does not match our required format, so they cannot create LL accounts.

## Implementation

Added `.mt` to the list of accepted email address extensions.

### Usage

Attempt email signup with a `.mt` email address.
