### PR TITLE
Change sender email

### DIFF
--- a/layup_list/settings.py
+++ b/layup_list/settings.py
@@ -151,7 +151,7 @@ EMAIL_HOST_USER = os.environ.get('EMAIL_HOST_USER')
 EMAIL_HOST_PASSWORD = os.environ.get('EMAIL_HOST_PASSWORD')
 EMAIL_PORT = os.environ.get('EMAIL_PORT')
 EMAIL_USE_TLS = os.environ.get('EMAIL_USE_TLS')
-DEFAULT_FROM_EMAIL = 'support@layuplist.com'
+DEFAULT_FROM_EMAIL = 'contrarians@dartmouth.edu'
 
 AUTH_PASSWORD_VALIDATORS = [
     {


### PR DESCRIPTION
We don't have access to the Sendgrid for `support@layuplist.com` outbound anymore. Changing to one we do have.