### PR TITLE
Swap to "support@layuplist.org"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Our <a href="https://github.com/layuplist/layup-list/issues">issues</a> page has
 
 To contribute code, make a pull request. Github has a great <a href="https://guides.github.com/activities/contributing-to-open-source/">guide</a> for how you can go about doing this.
 
-Feel free to email <a href="mailto:support@layuplist.com">support@layuplist.com</a> if you need any help.
+Feel free to email <a href="mailto:support@layuplist.org">support@layuplist.org</a> if you need any help.
 
 Local Setup (macOS or OS X)
 -----------------

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Check out <a href="https://github.com/layuplist/layup-list/blob/master/CONTRIBUT
 
 Our <a href="https://github.com/layuplist/layup-list/issues">issues</a> page has some ideas for buxfixes and feature improvements (though you aren't limited to this list).
 
-Feel free to email <a href="mailto:support@layuplist.com">support@layuplist.com</a> for help.
+Feel free to email <a href="mailto:support@layuplist.org">support@layuplist.org</a> for help.
 
 Features
 --------

--- a/apps/web/models/student.py
+++ b/apps/web/models/student.py
@@ -44,7 +44,7 @@ class Student(models.Model):
             send_mail(
                 'Your confirmation link',
                 'Please navigate to the following confirmation link: ' +
-                full_link, 'contrarians@dartmouth.edu',
+                full_link, constants.SUPPORT_EMAIL,
                 [self.user.email], fail_silently=False
             )
 

--- a/apps/web/templates/footer.html
+++ b/apps/web/templates/footer.html
@@ -1,7 +1,7 @@
 <div class="footer">
     <div class="footer-inner text-center">
         <h5>
-            <p><a class="support-link" href="mailto:support@layuplist.com">support@layuplist.com</a></p>
+            <p><a class="support-link" href="mailto:support@layuplist.org">support@layuplist.org</a></p>
         </h5>
         <a class="github-button" href="https://github.com/layuplist/layup-list" data-style="mega" data-count-href="/layuplist/layup-list/stargazers" data-count-api="/repos/layuplist/layup-list#stargazers_count" data-count-aria-label="# stargazers on GitHub" aria-label="Star layuplist/layup-list on GitHub">Star</a>
     </div>

--- a/layup_list/root_assets/humans.txt
+++ b/layup_list/root_assets/humans.txt
@@ -1,4 +1,4 @@
 LayupList.com
-support@layuplist.com
+support@layuplist.org
 Hanover, New Hampshire
 

--- a/layup_list/settings.py
+++ b/layup_list/settings.py
@@ -151,7 +151,7 @@ EMAIL_HOST_USER = os.environ.get('EMAIL_HOST_USER')
 EMAIL_HOST_PASSWORD = os.environ.get('EMAIL_HOST_PASSWORD')
 EMAIL_PORT = os.environ.get('EMAIL_PORT')
 EMAIL_USE_TLS = os.environ.get('EMAIL_USE_TLS')
-DEFAULT_FROM_EMAIL = 'contrarians@dartmouth.edu'
+DEFAULT_FROM_EMAIL = 'support@layuplist.org'
 
 AUTH_PASSWORD_VALIDATORS = [
     {
@@ -177,8 +177,8 @@ AUTH_PASSWORD_VALIDATORS = [
 
 
 if not DEBUG:
-    SERVER_EMAIL = 'support@layuplist.com'
-    ADMINS = [('Support', 'support@layuplist.com')]
+    SERVER_EMAIL = 'support@layuplist.org'
+    ADMINS = [('Support', 'support@layuplist.org')]
 
 
 SESSION_COOKIE_AGE = 3153600000  # 100 years

--- a/lib/constants.py
+++ b/lib/constants.py
@@ -1,6 +1,6 @@
 import os
 CURRENT_TERM = os.environ["CURRENT_TERM"]  # e.g. 16S
-SUPPORT_EMAIL = "support@layuplist.com"
+SUPPORT_EMAIL = "support@layuplist.org"
 REC_UPVOTE_REQ = 2
 OFFERINGS_THRESHOLD_FOR_TERM_UPDATE = int(
     os.environ["OFFERINGS_THRESHOLD_FOR_TERM_UPDATE"])


### PR DESCRIPTION
We've lost access to "support@layuplist.com", so I've setup a forward-only domain "layuplist.org", and setup "support@layuplist.org".

layuplist.org will redirect to .com