### PR TITLE
Uncomment (& update) Password Reset Views

### DIFF
--- a/layup_list/urls.py
+++ b/layup_list/urls.py
@@ -77,25 +77,25 @@ urlpatterns = [
     re_path(r'^accounts/confirmation$', views.confirmation, name="confirmation"),
 
     # password resets
-    # re_path(r'^accounts/password/reset/$', authviews.password_reset,
-    #     {
-    #         'post_reset_redirect': '/accounts/password/reset/done/',
-    #         'template_name': 'password_reset_form.html',
-    #         'html_email_template_name': 'password_reset_email.html',
-    #         'email_template_name': 'password_reset_email.html',
-    #     },
-    #     name="password_reset"),
-    # re_path(r'^accounts/password/reset/done/$', authviews.password_reset_done,
-    #     {'template_name': 'password_reset_done.html'}),
-    # re_path(r'^accounts/password/reset/(?P<uidb64>[0-9A-Za-z]+)-(?P<token>.+)/$',
-    #     authviews.password_reset_confirm,
-    #     {
-    #         'post_reset_redirect': '/accounts/password/done/',
-    #         'template_name': 'password_reset_confirm.html'
-    #     },
-    #     name="password_reset_confirm"),
-    # re_path(r'^accounts/password/done/$', authviews.password_reset_complete,
-    #     {'template_name': 'password_reset_complete.html'}),
+    re_path(r'^accounts/password/reset/$', authviews.PasswordResetView.as_view(),
+        {
+            'post_reset_redirect': '/accounts/password/reset/done/',
+            'template_name': 'password_reset_form.html',
+            'html_email_template_name': 'password_reset_email.html',
+            'email_template_name': 'password_reset_email.html',
+        },
+        name="password_reset"),
+    re_path(r'^accounts/password/reset/done/$', authviews.PasswordResetDoneView.as_view(),
+        {'template_name': 'password_reset_done.html'}, name="password_reset_done"), # explicitly set name that matches reverse_lazy() — has been strictly required since Django 2.0+
+    re_path(r'^accounts/password/reset/(?P<uidb64>[0-9A-Za-z]+)-(?P<token>.+)/$',
+        authviews.PasswordResetConfirmView.as_view(),
+        {
+            'post_reset_redirect': '/accounts/password/done/',
+            'template_name': 'password_reset_confirm.html'
+        },
+        name="password_reset_confirm"),
+    re_path(r'^accounts/password/done/$', authviews.PasswordResetCompleteView.as_view(),
+        {'template_name': 'password_reset_complete.html'}, name="password_reset_complete"), # explicitly set name that matches reverse_lazy()
 
     # root files (could also copy root_files/* to /staticfiles in run_collectstatic build script for production, but this seems more explicit)
     re_path(r"^favicon\.ico$", serve, {"document_root": settings.ROOT_ASSETS_DIR, "path": "favicon.ico"}),


### PR DESCRIPTION
During the refactor to Python 3.11, password reset views were left commented out. This change adds the functionality back.

Also updated usage of the class-based views in `urls.py` to match the syntax now required in newer Django versions (including a `name` param on URLs defined by `reverse_lazy()`). These changes only affect password reset views.