### PR TITLE
Resend activation links to accounts made during email outage

### DIFF
--- a/apps/web/views.py
+++ b/apps/web/views.py
@@ -109,6 +109,23 @@ def auth_login(request):
                         "first.")
                 })
         else:
+            # Check if user is affected by email outage — can't do this in the above else block since that isn't fired (for some reason `authenticate` for non-activated users returns None instead of the user)
+            user = User.objects.filter(username=username).first()
+            if user:
+                emails_fixed_at = datetime.datetime.fromisoformat("2025-04-02 14:51:41.666898+00") # when emails were fixed (not resending links for ppl who signed up after since they got their conf link)
+                if not user.is_active and user.last_name != "RESENT_CONFIRMATION" and user.date_joined < emails_fixed_at:
+                    user.last_name = "RESENT_CONFIRMATION"
+                    user.save()
+                    # resend confirmation link
+                    student = Student.objects.get(user=user)
+                    student.send_confirmation_link(request)
+                    return render(request, 'login.html', {
+                        "error": (
+                            "We sent a new confirmation link to your email. "
+                            "Check your inbox (and spam) and follow the instructions to activate your account."
+                        )
+                    })
+                # else: User has already resent confirmation (after emails have started working again). We do not resend confirmation link.
             return render(request, 'login.html', {"error": "Invalid login."})
     elif request.method == 'GET':
         return render(request, 'login.html')
@@ -143,6 +160,7 @@ def confirmation(request):
             })
 
         student.user.is_active = True
+        student.user.last_name = "" # remove "RESENT_CONFIRMATION" if it exists
         student.user.save()
         return render(request, 'confirmation.html', {
             'already_confirmed': False


### PR DESCRIPTION
# Resend Activation Links
Even though activation links and emails are now fixed, some people made accounts while they were down (especially in the week between the Python 3 update and the email fix). Since the only way to activate an account (and login) is to click on that activation link, these accounts are in limbo.

This change resends activation links to those affected accounts when they attempt to login. We only send these new links once to each account (tracked via the `last_name` field of the user, and reset after activation).

## Instructions for Affected Accounts

1. Log in to Layup List using the email you created your account with.
2. Navigate to your inbox (and spam) and look for a confirmation email from Layup List Support
3. Click the link in the email and ta-da, your account should be activated.

## Referenced Issue(s)

- #77 